### PR TITLE
Release update

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -39,7 +39,7 @@ identifiers:
     value: "https://github.com/Imageomics/bioclip-2/releases/tag/v1.0.1"
   - description: "The GitHub URL of the commit tagged with v1.0.1."
     type: url
-    value: "https://github.com/Imageomics/bioclip-2/tree/<commit-hash>" # update on release 
+    value: "https://github.com/Imageomics/bioclip-2/tree/92bf5e1f74e40df91a02c4dd6cad63b3396c94cf"
 keywords:
   - clip
   - biology

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Our code (this repository):
   author = {Jianyang Gu and Samuel Stevens and Elizabeth G. Campolongo and Matthew J. Thompson and Net Zhang and Jiaman Wu and Zheda Mai},
   doi = {10.5281/zenodo.15644363},
   title = {{B}io{CLIP} 2},
-  version = {1.0.0},
-  month = {jun},
+  version = {1.0.1},
+  month = {sep},
   year = {2025}
 }
 ```


### PR DESCRIPTION
Adds commit hash of the release to the citation file, and increments the version in the citation in the README.

@vimar-gu, I started a `.zenodo.json` and validation workflow for it (as described in the [Imageomics-Guide](https://imageomics.github.io/Imageomics-guide/wiki-guide/DOI-Generation/#metadata-tracking)), but will put that in another PR before our next version update.